### PR TITLE
Fix broken column

### DIFF
--- a/src/main/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaController.java
+++ b/src/main/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaController.java
@@ -102,7 +102,7 @@ public class ProjectIdeaController {
             return "redirect:/";
         }
 
-        boolean errors =false;
+        boolean errors = false;
 
         model.addAttribute("titleHasErrors", false);
         model.addAttribute("detailHasErrors", false);
@@ -125,6 +125,11 @@ public class ProjectIdeaController {
             model.addAttribute("detailErrors", "Please add some more detail (at least 30 chars)");
             model.addAttribute("detailHasErrors", true);
             errors = true;
+        } else if (idea.getDetails().length() > 255) {
+            model.addAttribute("detailErrors", "Description was too long; please limit it to 255 characters (currently "
+                    + idea.getDetails().length() + " characters)");
+            model.addAttribute("detailHasErrors", true);
+            errors = true;
         }
 
         if (!errors) {
@@ -141,12 +146,12 @@ public class ProjectIdeaController {
         }
 
         model.addAttribute("idea", idea);
-    
+
         logger.info("leaving ProjectIdeaController addIdea:");
-        logger.info("idea"+idea);
+        logger.info("idea" + idea);
 
         return "index";
-        
+
     }
 
 }

--- a/src/main/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaController.java
+++ b/src/main/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaController.java
@@ -9,13 +9,7 @@ import edu.ucsb.cs48.s20.demo.repositories.StudentRepository;
 import edu.ucsb.cs48.s20.demo.services.CSVToObjectService;
 import edu.ucsb.cs48.s20.demo.services.MembershipService;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.List;
 import java.util.Optional;
-
-import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,8 +22,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller

--- a/src/main/java/edu/ucsb/cs48/s20/demo/entities/ProjectIdea.java
+++ b/src/main/java/edu/ucsb/cs48/s20/demo/entities/ProjectIdea.java
@@ -6,12 +6,12 @@ import com.opencsv.bean.CsvBindByPosition;
 import java.util.List;
 import java.util.Objects;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
 import javax.persistence.OneToOne;
 import javax.validation.constraints.NotBlank;
 
@@ -20,16 +20,16 @@ public class ProjectIdea {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-   
+
     @OneToOne
     @JoinColumn(name = "student_id")
     private Student student;
-    
+
     @NotBlank
     private String title;
 
     @NotBlank
-    @Column(columnDefinition = "LONGTEXT")
+    @Lob
     private String details;
 
     public long getId() {
@@ -56,8 +56,6 @@ public class ProjectIdea {
         this.title = title;
     }
 
-   
-
     public String getDetails() {
         return this.details;
     }
@@ -65,7 +63,6 @@ public class ProjectIdea {
     public void setDetails(String details) {
         this.details = details;
     }
-
 
     @Override
     public boolean equals(Object o) {
@@ -75,24 +72,19 @@ public class ProjectIdea {
             return false;
         }
         ProjectIdea projectIdea = (ProjectIdea) o;
-        return id == projectIdea.id && Objects.equals(student, projectIdea.student) && Objects.equals(title, projectIdea.title) && Objects.equals(details, projectIdea.details);
+        return id == projectIdea.id && Objects.equals(student, projectIdea.student)
+                && Objects.equals(title, projectIdea.title) && Objects.equals(details, projectIdea.details);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(id, student, title, details);
     }
-    
 
     @Override
     public String toString() {
-        return "{" +
-            " id='" + getId() + "'" +
-            ", student='" + getStudent() + "'" +
-            ", title='" + getTitle() + "'" +
-            ", details='" + getDetails() + "'" +
-            "}";
+        return "{" + " id='" + getId() + "'" + ", student='" + getStudent() + "'" + ", title='" + getTitle() + "'"
+                + ", details='" + getDetails() + "'" + "}";
     }
-
 
 }

--- a/src/main/java/edu/ucsb/cs48/s20/demo/entities/ProjectIdea.java
+++ b/src/main/java/edu/ucsb/cs48/s20/demo/entities/ProjectIdea.java
@@ -29,7 +29,6 @@ public class ProjectIdea {
     private String title;
 
     @NotBlank
-    @Lob
     private String details;
 
     public long getId() {

--- a/src/main/java/edu/ucsb/cs48/s20/demo/entities/ProjectIdea.java
+++ b/src/main/java/edu/ucsb/cs48/s20/demo/entities/ProjectIdea.java
@@ -1,9 +1,5 @@
 package edu.ucsb.cs48.s20.demo.entities;
 
-import com.opencsv.bean.CsvBindByName;
-import com.opencsv.bean.CsvBindByPosition;
-
-import java.util.List;
 import java.util.Objects;
 
 import javax.persistence.Entity;
@@ -11,7 +7,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.OneToOne;
 import javax.validation.constraints.NotBlank;
 


### PR DESCRIPTION
This PR addresses the PSQL "no relation" error that was being caused by an incorrect `@Column` configuration by simply dropping it and restricting input to 255 max length.