### PR TITLE
Review ideas that have already met minimum, 

### DIFF
--- a/src/main/java/edu/ucsb/cs48/s20/demo/advice/AuthControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs48/s20/demo/advice/AuthControllerAdvice.java
@@ -51,6 +51,7 @@ public class AuthControllerAdvice {
     @ModelAttribute("picture")
     public String getPicture(OAuth2AuthenticationToken token){
         if (token == null) return "";
+        if (token.getPrincipal().getAttributes().get("picture") == null) return "";
         return token.getPrincipal().getAttributes().get("picture").toString();
     }
 

--- a/src/main/java/edu/ucsb/cs48/s20/demo/advice/StudentFlowAdvice.java
+++ b/src/main/java/edu/ucsb/cs48/s20/demo/advice/StudentFlowAdvice.java
@@ -104,6 +104,7 @@ public class StudentFlowAdvice {
 			return null;
 		}
 
+		// Case 1: deliver projects with < NUMBER_OF_REVIEWS_REQUIRED reviews currently
 		Stream<ProjectIdea> projects = StreamSupport.stream(projectIdeaRepository.findAll().spliterator(), false)
 				.filter((idea) -> {
 					List<Review> reviews = reviewRepository.findByIdea(idea);
@@ -115,6 +116,21 @@ public class StudentFlowAdvice {
 				});
 
 		List<ProjectIdea> remainingProjects = projects.collect(Collectors.toList());
+
+		// Case 2: deliver any project that fits the criteria
+		if (remainingProjects.isEmpty()) {
+			projects = StreamSupport.stream(projectIdeaRepository.findAll().spliterator(), false)
+					.filter((idea) -> {
+						List<Review> reviews = reviewRepository.findByIdea(idea);
+						if (idea.getStudent().equals(student))
+							return false;
+						if (reviews.stream().anyMatch((review) -> review.getReviewer().equals(student)))
+							return false;
+						return true;
+					});
+
+			remainingProjects = projects.collect(Collectors.toList());
+		}
 
 		if (remainingProjects.isEmpty()) {
 			return null;

--- a/src/main/java/edu/ucsb/cs48/s20/demo/controllers/ReviewsController.java
+++ b/src/main/java/edu/ucsb/cs48/s20/demo/controllers/ReviewsController.java
@@ -145,11 +145,7 @@ public class ReviewsController {
             review.setRating(Integer.parseInt(reviewBean.getRating()));
             review.setDetails(reviewBean.getDetails());
             reviewRepository.save(review);
-            if (studentFlowAdvice.getReviewsNeeded(token) < 1) {
-                return "redirect:/";
-            } else {
-                return "redirect:/reviews/perform";
-            }
+            return "redirect:/reviews/perform";
 
         }
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -31,7 +31,7 @@
         </div>
         <div th:unless="${reviewsNeededFromStudent} > 0">
           <div class="alert alert-success" role="alert">
-            <span><strong>All done!</strong> You have reviewed a sufficient number of project ideas.</span>
+            <span><strong>All done!</strong> You have reviewed a sufficient number of project ideas. <a href="reviews/perform">Click here to review another project idea</a></span>
           </div>
         </div>
 

--- a/src/main/resources/templates/reviews/perform.html
+++ b/src/main/resources/templates/reviews/perform.html
@@ -10,9 +10,19 @@
 
       <br /><h1>Giving Reviews</h1>
       <br />
-      <div class="alert alert-warning" role="alert">
-        <span th:text="'You must review ' + ${reviewsNeededFromStudent} + ' more project ideas'"></span>
+
+      <!-- Conditional alert if user needs to submit more reviews or not !-->
+      <div th:if="${reviewsNeededFromStudent} > 0">
+        <div class="alert alert-warning" role="alert">
+          <span th:text="'You must review ' + ${reviewsNeededFromStudent} + ' more project ideas'"></span>
+        </div>
       </div>
+      <div th:unless="${reviewsNeededFromStudent} > 0">
+        <div class="alert alert-success" role="alert">
+          <span>You have reviewed a sufficient number of project ideas. Feel free to continue submitting additional reviews</span>
+        </div>
+      </div>
+
       <br />
       <div th:if="${randomIdeaThatNeedsAReview}">
         <h3 th:text="'Project Idea: ' + ${randomIdeaThatNeedsAReview.title}"></h3>
@@ -45,7 +55,7 @@
 
       <div th:unless="${randomIdeaThatNeedsAReview}">
         <div class="alert alert-danger" role="alert">
-          No ideas currently need a review; please check back later.
+          No ideas currently need a review; please refresh this page in a moment
         </div>
       </div>
 


### PR DESCRIPTION
Acceptance criteria:
- [x] If there are projectIdea that don't yet have the minimum number of reviews, only those are offered. (that's the existing implementation, but here as an acceptance criteria to indicate: don't break this.)  
- [x] Don't let students review a projectIdea they already reviewed a second time (existing functionality)
- [x] Don't let students review their own project idea (existing functionality)
- [x] If there are NO projectIdeas that don't yet have the minimum number of reviews, then offer the chance to review any random project idea (from among those the student has not reviewed yet, and those that are not the student's own idea.)
- [x] Only deny the chance to review a project idea if there are no projectIdeas that the student has not already reviewed, not including their own.
 
In addition, 
- [x] Allow students to access review flow from home screen
- [x] Keep students in the review flow even after they have completed 5 reviews, letting them know they have completed the requirement but can continue to review if they want