### PR TITLE
Test student idea submission flow

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,5 +9,7 @@ INSERT INTO student (email, fname, lname, perm) VALUES ('andrewgege@gmail.co','A
 INSERT INTO student (email, fname, lname, perm, project_idea_id) VALUES ('colebergmann@gmail.com','Cole','Bergmann', 44444, 2);
 INSERT INTO student (email, fname, lname, perm) VALUES ('bryan.terce@gmail.com','Bryan','Terce', 566555);
 INSERT INTO student (email, fname, lname, perm) VALUES ('andylord288@gmail.com','Andrew','Lu', 777777);
+INSERT INTO student (email, fname, lname, perm) VALUES ('jacquimai27@gmail.com','Jacqui','Mai', 123456);
+
 
 INSERT INTO review (details, rating, idea_id, student_id) VALUES ('test details', 5, 1, 1)

--- a/src/test/java/edu/ucsb/cs48/s20/demo/controllers/HomePageTest.java
+++ b/src/test/java/edu/ucsb/cs48/s20/demo/controllers/HomePageTest.java
@@ -87,16 +87,7 @@ public class HomePageTest {
     since this is a new student, they should have no submitted ideas and should see the text box*/
     @Test
     public void studentWithNoSubmissions_hasTextBox() throws Exception{
-        when(aca.getFirstName(any())).thenReturn("Joe");
-        when(aca.getLastName(any())).thenReturn("Gaucho");
-        when(aca.getEmail(any())).thenReturn("joegaucho@ucsb.edu");
-        when(aca.getRole(any())).thenReturn("Student");
-        when(aca.getIsLoggedIn(any())).thenReturn(true);
-        when(sfa.needsToSubmitProjectIdea(any())).thenReturn(true);
-        when(sfa.getReviewsNeeded(any())).thenReturn(3);
-        // when(aca.getRole(any())).thenReturn("Student");
-        when(aca.getIsStudent(any())).thenReturn(true);
-        System.out.println("STUDENT? "+(aca.getIsStudent((OAuth2AuthenticationToken) mockAuthentication)));
+        when(sfa.needsToSubmitProjectIdea((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(true);
 
         mvc.perform(MockMvcRequestBuilders.get("/").with(authentication(mockAuthentication)).accept(MediaType.TEXT_HTML))
         .andExpect(status().isOk()).andExpect(xpath("/html/body/div/div[1]/p[1]").string("To get started, submit your project idea below."))

--- a/src/test/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaControllerTest.java
+++ b/src/test/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaControllerTest.java
@@ -1,12 +1,11 @@
 package edu.ucsb.cs48.s20.demo.controllers;
+
 import java.util.Optional;
+
 import edu.ucsb.cs48.s20.demo.advice.AuthControllerAdvice;
 import edu.ucsb.cs48.s20.demo.advice.StudentFlowAdvice;
 import edu.ucsb.cs48.s20.demo.entities.Student;
 import edu.ucsb.cs48.s20.demo.entities.ProjectIdea;
-import edu.ucsb.cs48.s20.demo.formbeans.Idea;
-import edu.ucsb.cs48.s20.demo.entities.Student;
-import edu.ucsb.cs48.s20.demo.entities.Review;
 import edu.ucsb.cs48.s20.demo.formbeans.Idea;
 import edu.ucsb.cs48.s20.demo.repositories.AppUserRepository;
 import edu.ucsb.cs48.s20.demo.repositories.ProjectIdeaRepository;
@@ -21,8 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -30,32 +27,20 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
 import utils.OAuthUtils;
-
 import java.util.Arrays;
-import java.util.List;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @WebAppConfiguration
 @RunWith(SpringRunner.class)
-
 public class ProjectIdeaControllerTest{
-    @Autowired
-    private MockMvc mvc;
-
     @MockBean
     private AuthControllerAdvice aca;
 
@@ -92,7 +77,7 @@ public class ProjectIdeaControllerTest{
         when(ms.isMember((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(true);
     }
 
-    /*ADD ACTION TESTS*/
+    /*after valid submission, there is a redirect to idea reviews page*/
     /*when a student submits a VALID idea (title/deets are proper lengths), it is added to the idea db and assigned to the student*/
     @Test
     public void addValidIdea_saveToDb() throws Exception{
@@ -109,8 +94,9 @@ public class ProjectIdeaControllerTest{
         when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
         when(sfa.getStudent((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(jorbus);
 
-        projectIdeaController.addIdea(idea, model, (OAuth2AuthenticationToken) mockAuthentication, null, redirAttrs);
+        String ret = projectIdeaController.addIdea(idea, model, (OAuth2AuthenticationToken) mockAuthentication, null, redirAttrs);
 
+        assert(ret.equals("redirect:/reviews/perform"));
         assert(model.getAttribute("titleHasErrors").equals(false));
         assert(model.getAttribute("detailHasErrors").equals(false));
         final ArgumentCaptor<ProjectIdea> captor = ArgumentCaptor.forClass(ProjectIdea.class);
@@ -120,32 +106,11 @@ public class ProjectIdeaControllerTest{
         assert(captor.getValue().getTitle().equals("TITLE"));
         assert(captor.getValue().getDetails().equals("This is a valid description because it is more than 30 characters."));
         assert(jorbus.getProjectIdea().equals(captor.getValue()));
-
     }
-    /*COME BACK TO THIS*/
-    /*after valid submission, there is a redirect to idea reviews page*/
-    // @Test
-    // public void studentSubmitsValidIdea_redirectToReviewsPage() throws Exception{
-    //     Model model = new ExtendedModelMap();
-    //     RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
+ 
 
-    //     Idea idea = new Idea();
-    //     idea.setTitle("TITLE");
-    //     idea.setDetails("This is a valid description because it is more than 30 characters.");
-
-    //     Student jorbus = new Student();
-    //     jorbus.setId(5);
-
-    //     when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
-    //     when(sfa.getStudent((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(jorbus);
-
-        
-    //     mvc.perform(MockMvcRequestBuilders.post("/ideas/add").with(authentication(mockAuthentication)).param("Form data", "'title':'TITLE','details':'This is a valid description because it is more than 30 characters.'"))
-    //     .andExpect(status().is3xxRedirection())
-    //     .andExpect(redirectedUrl("/reviews/perform"));
-    // }
-
-    /*submitting an invalid idea (title/deets improper lengths) flips model attrs titleHasErrors, detailsHasErrors to true, adds title/deet err strings to model*/
+    /*submitting an invalid idea sets model attrs titleHasErrors, detailsHasErrors and adds title/detail err strings to model*/
+    /*redirect to index page*/
     @Test
     public void addInvalidIdea_noSaveToDb() throws Exception{
         Model model = new ExtendedModelMap();
@@ -161,8 +126,9 @@ public class ProjectIdeaControllerTest{
         when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
         when(sfa.getStudent((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(jorbus);
 
-        projectIdeaController.addIdea(idea, model, (OAuth2AuthenticationToken) mockAuthentication, null, redirAttrs);
+        String ret = projectIdeaController.addIdea(idea, model, (OAuth2AuthenticationToken) mockAuthentication, null, redirAttrs);
 
+        assert(ret.equals("index"));
         assert(model.getAttribute("titleHasErrors").equals(true));
         assert(model.getAttribute("titleErrors").equals("Title is too short (4 characters minimum). Currently: 0 chars."));
         assert(model.getAttribute("detailHasErrors").equals(true));
@@ -172,8 +138,6 @@ public class ProjectIdeaControllerTest{
         verify(sr, times(0)).save(any());
         assert(model.getAttribute("idea").equals(idea));
     }
-    /*COME BACK TO THIS*/
-    /*stay on index page (no redirect)*/
    
     /*DELETE*/
     /*only an admin can perform this action*/
@@ -184,15 +148,16 @@ public class ProjectIdeaControllerTest{
 
         when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
 
-        projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
-
+        String ret = projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
+        
+        assert(ret.equals("redirect:/"));
         verify(pir, times(0)).delete(any());
         verify(sr, times(0)).save(any());
         assert(redirAttrs.getFlashAttributes().containsKey("alertDanger"));
         assert(redirAttrs.getFlashAttributes().containsValue("You do not have permission to access that page"));
     }
 
-    /*try to delete an idea that DNE- no deletion triggered (look into checking redirectAttrs)*/
+    /*try to delete an idea that does not exist- no deletion triggered)*/
     @Test
     public void deleteIdeaThatDNE_noDbDeletion() throws Exception{
         Model model = new ExtendedModelMap();
@@ -200,14 +165,17 @@ public class ProjectIdeaControllerTest{
 
         when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Admin");
 
-        projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
+        String ret = projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
 
+        assert(ret.equals("redirect:/ideas"));
         verify(pir, times(1)).findById((long)5);
         verify(sr, times(0)).save(any());
         assert(redirAttrs.getFlashAttributes().containsKey("alertDanger"));
         assert(redirAttrs.getFlashAttributes().containsValue("ProjectIdea with that id does not exist."));
     }
+
     /*try to delete valid idea- delete on idea repo triggered, save on student- check redirectAttrs for success msg*/
+    /*redirect to ideas index page*/
     @Test
     public void deleteIdeaThatExists_dbDeletion() throws Exception{
         Model model = new ExtendedModelMap();
@@ -228,29 +196,31 @@ public class ProjectIdeaControllerTest{
 
         when(pir.findById((long) 5)).thenReturn(Optional.of(pi));
 
-        projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
+        String ret = projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
 
+        assert(ret.equals("redirect:/ideas"));
         verify(pir, times(1)).findById((long)5);
         verify(sr, times(1)).save(jorbus);
         assert(redirAttrs.getFlashAttributes().containsKey("alertSuccess"));
-        System.out.println("HERE attr: "+redirAttrs.getFlashAttributes());
         assert(redirAttrs.getFlashAttributes().containsValue("Idea TITLE for student Jorbus The III successfully deleted."));
     }
-    /*redirect to ideas index page*/
 
     /*INDEX PAGE*/
+    /*redirect when not logged in as admin*/
     public void indexNotAdmin_redirectWithFlashMsg() throws Exception{
         Model model = new ExtendedModelMap();
         RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
 
         when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
 
-        projectIdeaController.ideas(model, (OAuth2AuthenticationToken) mockAuthentication, redirAttrs);
+        String ret = projectIdeaController.ideas(model, (OAuth2AuthenticationToken) mockAuthentication, redirAttrs);
 
+        assert(ret.equals("redirect:/"));
         assert(redirAttrs.getFlashAttributes().containsKey("alertDanger"));
         assert(redirAttrs.getFlashAttributes().containsValue("You do not have permission to access that page"));
     }
-    /*only an admin can access this page*/
+
+    /*success when admin*/
     @Test
     public void indexAdmin_showIdeaList() throws Exception{
         Model model = new ExtendedModelMap();
@@ -267,14 +237,12 @@ public class ProjectIdeaControllerTest{
         when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Admin");
         when(pir.findAll()).thenReturn(pi_list);
 
-        projectIdeaController.ideas(model, (OAuth2AuthenticationToken) mockAuthentication, redirAttrs);
+        String ret = projectIdeaController.ideas(model, (OAuth2AuthenticationToken) mockAuthentication, redirAttrs);
 
+        assert(ret.equals("ideas/index"));
         verify(pir, times(1)).findAll();
         assert(model.getAttribute("ideas").equals(pi_list));
 
 
     }
-    /*if not admin, then redirected to homepage*/
-
-
 }

--- a/src/test/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaControllerTest.java
+++ b/src/test/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaControllerTest.java
@@ -1,0 +1,140 @@
+package edu.ucsb.cs48.s20.demo.controllers;
+
+import edu.ucsb.cs48.s20.demo.advice.AuthControllerAdvice;
+import edu.ucsb.cs48.s20.demo.advice.StudentFlowAdvice;
+import edu.ucsb.cs48.s20.demo.entities.Student;
+import edu.ucsb.cs48.s20.demo.entities.ProjectIdea;
+import edu.ucsb.cs48.s20.demo.formbeans.Idea;
+import edu.ucsb.cs48.s20.demo.entities.Student;
+import edu.ucsb.cs48.s20.demo.entities.Review;
+import edu.ucsb.cs48.s20.demo.formbeans.Idea;
+import edu.ucsb.cs48.s20.demo.repositories.AppUserRepository;
+import edu.ucsb.cs48.s20.demo.repositories.ProjectIdeaRepository;
+import edu.ucsb.cs48.s20.demo.repositories.StudentRepository;
+import edu.ucsb.cs48.s20.demo.services.GoogleMembershipService;
+import edu.ucsb.cs48.s20.demo.services.MembershipService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+import utils.OAuthUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@WebAppConfiguration
+@RunWith(SpringRunner.class)
+
+public class ProjectIdeaControllerTest{
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private AuthControllerAdvice aca;
+
+    @MockBean
+    private ClientRegistrationRepository crr;
+
+    @MockBean
+    private MembershipService ms;
+
+    @Autowired
+    private ProjectIdeaController projectIdeaController;
+
+    @MockBean
+    private GoogleMembershipService gms;
+
+    @MockBean
+    private AppUserRepository aur;
+
+    @MockBean
+    private ProjectIdeaRepository pir;
+
+    @MockBean
+    private StudentRepository sr;
+
+    @MockBean
+    private StudentFlowAdvice sfa;
+
+    private Authentication mockAuthentication;
+
+    @Before
+    public void setUp() {
+        OAuth2User principal = OAuthUtils.createOAuth2User("Chris Gaucho", "cgaucho@ucsb.edu");
+        mockAuthentication = OAuthUtils.getOauthAuthenticationFor(principal);
+        when(ms.isMember((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(true);
+    }
+
+    /*ADD ACTION TESTS*/
+    /*when a student submits a VALID idea (title/deets are proper lengths), it is added to the idea db*/
+    /*student attributes are set - submittedIdea = true*/
+    /*after submission, there is a redirect to idea reviews page*/
+    @Test
+    public void studentSubmitsValidIdea_saveToDbAndRedirect() throws Exception{
+        Model model = new ExtendedModelMap();
+        RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
+
+        Idea idea = new Idea();
+        idea.setTitle("TITLE");
+        idea.setDetails("This is a valid description because it is more than 30 characters.");
+
+        Student jorbus = new Student();
+        jorbus.setId(5);
+
+        when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
+        when(sfa.getStudent((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(jorbus);
+
+        projectIdeaController.addIdea(idea, model, (OAuth2AuthenticationToken) mockAuthentication, null, redirAttrs);
+
+        assert(model.getAttribute("titleHasErrors").equals(false));
+        assert(model.getAttribute("detailHasErrors").equals(false));
+        final ArgumentCaptor<ProjectIdea> captor = ArgumentCaptor.forClass(ProjectIdea.class);
+        verify(pir, times(1)).save(captor.capture());
+        verify(sr, times(1)).save(jorbus);
+        assert(captor.getValue().getStudent().equals(jorbus));
+        assert(captor.getValue().getTitle().equals("TITLE"));
+        assert(captor.getValue().getDetails().equals("This is a valid description because it is more than 30 characters."));
+        assert(jorbus.getProjectIdea().equals(captor.getValue()));
+    }
+
+    /*submitting an invalid idea (title/deets improper lengths) flips model attrs titleHasErrors, detailsHasErrors to true, adds title/deet err strings to model*/
+    /*stay on index page (no redirect)*/
+
+    /*DELETE*/
+    /*only an admin can perform this action*/
+    /*try to delete an idea that DNE- no deletion triggered (look into checking redirectAttrs)*/
+    /*try to delete valid idea- delete on idea repo triggered, save on student- check redirectAttrs for success msg*/
+    /*redirect to ideas index page*/
+
+
+    /*INDEX PAGE*/
+    /*only an admin can access this page*/
+    /*if not admin, then redirected to homepage*/
+
+
+}

--- a/src/test/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaControllerTest.java
+++ b/src/test/java/edu/ucsb/cs48/s20/demo/controllers/ProjectIdeaControllerTest.java
@@ -1,5 +1,5 @@
 package edu.ucsb.cs48.s20.demo.controllers;
-
+import java.util.Optional;
 import edu.ucsb.cs48.s20.demo.advice.AuthControllerAdvice;
 import edu.ucsb.cs48.s20.demo.advice.StudentFlowAdvice;
 import edu.ucsb.cs48.s20.demo.entities.Student;
@@ -30,6 +30,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
@@ -40,9 +41,10 @@ import utils.OAuthUtils;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -91,11 +93,9 @@ public class ProjectIdeaControllerTest{
     }
 
     /*ADD ACTION TESTS*/
-    /*when a student submits a VALID idea (title/deets are proper lengths), it is added to the idea db*/
-    /*student attributes are set - submittedIdea = true*/
-    /*after submission, there is a redirect to idea reviews page*/
+    /*when a student submits a VALID idea (title/deets are proper lengths), it is added to the idea db and assigned to the student*/
     @Test
-    public void studentSubmitsValidIdea_saveToDbAndRedirect() throws Exception{
+    public void addValidIdea_saveToDb() throws Exception{
         Model model = new ExtendedModelMap();
         RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
 
@@ -120,20 +120,160 @@ public class ProjectIdeaControllerTest{
         assert(captor.getValue().getTitle().equals("TITLE"));
         assert(captor.getValue().getDetails().equals("This is a valid description because it is more than 30 characters."));
         assert(jorbus.getProjectIdea().equals(captor.getValue()));
+
     }
+    /*COME BACK TO THIS*/
+    /*after valid submission, there is a redirect to idea reviews page*/
+    // @Test
+    // public void studentSubmitsValidIdea_redirectToReviewsPage() throws Exception{
+    //     Model model = new ExtendedModelMap();
+    //     RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
+
+    //     Idea idea = new Idea();
+    //     idea.setTitle("TITLE");
+    //     idea.setDetails("This is a valid description because it is more than 30 characters.");
+
+    //     Student jorbus = new Student();
+    //     jorbus.setId(5);
+
+    //     when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
+    //     when(sfa.getStudent((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(jorbus);
+
+        
+    //     mvc.perform(MockMvcRequestBuilders.post("/ideas/add").with(authentication(mockAuthentication)).param("Form data", "'title':'TITLE','details':'This is a valid description because it is more than 30 characters.'"))
+    //     .andExpect(status().is3xxRedirection())
+    //     .andExpect(redirectedUrl("/reviews/perform"));
+    // }
 
     /*submitting an invalid idea (title/deets improper lengths) flips model attrs titleHasErrors, detailsHasErrors to true, adds title/deet err strings to model*/
-    /*stay on index page (no redirect)*/
+    @Test
+    public void addInvalidIdea_noSaveToDb() throws Exception{
+        Model model = new ExtendedModelMap();
+        RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
 
+        Idea idea = new Idea();
+        idea.setTitle("");
+        idea.setDetails("");
+
+        Student jorbus = new Student();
+        jorbus.setId(5);
+
+        when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
+        when(sfa.getStudent((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(jorbus);
+
+        projectIdeaController.addIdea(idea, model, (OAuth2AuthenticationToken) mockAuthentication, null, redirAttrs);
+
+        assert(model.getAttribute("titleHasErrors").equals(true));
+        assert(model.getAttribute("titleErrors").equals("Title is too short (4 characters minimum). Currently: 0 chars."));
+        assert(model.getAttribute("detailHasErrors").equals(true));
+        assert(model.getAttribute("detailErrors").equals("Please add some more detail (at least 30 characters). Currently: 0 chars."));
+
+        verify(pir, times(0)).save(any());
+        verify(sr, times(0)).save(any());
+        assert(model.getAttribute("idea").equals(idea));
+    }
+    /*COME BACK TO THIS*/
+    /*stay on index page (no redirect)*/
+   
     /*DELETE*/
     /*only an admin can perform this action*/
+    @Test
+    public void deleteNotAdmin_redirectWithFlashMsg() throws Exception{
+        Model model = new ExtendedModelMap();
+        RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
+
+        when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
+
+        projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
+
+        verify(pir, times(0)).delete(any());
+        verify(sr, times(0)).save(any());
+        assert(redirAttrs.getFlashAttributes().containsKey("alertDanger"));
+        assert(redirAttrs.getFlashAttributes().containsValue("You do not have permission to access that page"));
+    }
+
     /*try to delete an idea that DNE- no deletion triggered (look into checking redirectAttrs)*/
+    @Test
+    public void deleteIdeaThatDNE_noDbDeletion() throws Exception{
+        Model model = new ExtendedModelMap();
+        RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
+
+        when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Admin");
+
+        projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
+
+        verify(pir, times(1)).findById((long)5);
+        verify(sr, times(0)).save(any());
+        assert(redirAttrs.getFlashAttributes().containsKey("alertDanger"));
+        assert(redirAttrs.getFlashAttributes().containsValue("ProjectIdea with that id does not exist."));
+    }
     /*try to delete valid idea- delete on idea repo triggered, save on student- check redirectAttrs for success msg*/
+    @Test
+    public void deleteIdeaThatExists_dbDeletion() throws Exception{
+        Model model = new ExtendedModelMap();
+        RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
+
+        when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Admin");
+
+        Student jorbus = new Student();
+        jorbus.setFname("Jorbus");
+        jorbus.setLname("The III");
+        jorbus.setId(5);
+
+        ProjectIdea pi = new ProjectIdea();
+        pi.setTitle("TITLE");
+        pi.setDetails("This is a valid description because it is more than 30 characters.");
+        pi.setId(5);
+        pi.setStudent(jorbus);
+
+        when(pir.findById((long) 5)).thenReturn(Optional.of(pi));
+
+        projectIdeaController.deleteIdea((long) 5, model, redirAttrs, (OAuth2AuthenticationToken) mockAuthentication);
+
+        verify(pir, times(1)).findById((long)5);
+        verify(sr, times(1)).save(jorbus);
+        assert(redirAttrs.getFlashAttributes().containsKey("alertSuccess"));
+        System.out.println("HERE attr: "+redirAttrs.getFlashAttributes());
+        assert(redirAttrs.getFlashAttributes().containsValue("Idea TITLE for student Jorbus The III successfully deleted."));
+    }
     /*redirect to ideas index page*/
 
-
     /*INDEX PAGE*/
+    public void indexNotAdmin_redirectWithFlashMsg() throws Exception{
+        Model model = new ExtendedModelMap();
+        RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
+
+        when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Student");
+
+        projectIdeaController.ideas(model, (OAuth2AuthenticationToken) mockAuthentication, redirAttrs);
+
+        assert(redirAttrs.getFlashAttributes().containsKey("alertDanger"));
+        assert(redirAttrs.getFlashAttributes().containsValue("You do not have permission to access that page"));
+    }
     /*only an admin can access this page*/
+    @Test
+    public void indexAdmin_showIdeaList() throws Exception{
+        Model model = new ExtendedModelMap();
+        RedirectAttributes redirAttrs = new RedirectAttributesModelMap();
+
+        ProjectIdea p1 = new ProjectIdea();
+        p1.setId(1);
+        ProjectIdea p2 = new ProjectIdea();
+        p2.setId(2);
+        ProjectIdea p3 = new ProjectIdea();
+        p3.setId(3);
+
+        Iterable<ProjectIdea> pi_list = Arrays.asList(p1,p2, p3);
+        when(ms.role((OAuth2AuthenticationToken) mockAuthentication)).thenReturn("Admin");
+        when(pir.findAll()).thenReturn(pi_list);
+
+        projectIdeaController.ideas(model, (OAuth2AuthenticationToken) mockAuthentication, redirAttrs);
+
+        verify(pir, times(1)).findAll();
+        assert(model.getAttribute("ideas").equals(pi_list));
+
+
+    }
     /*if not admin, then redirected to homepage*/
 
 

--- a/src/test/java/edu/ucsb/cs48/s20/demo/ui/HomePageHTMLTest.java
+++ b/src/test/java/edu/ucsb/cs48/s20/demo/ui/HomePageHTMLTest.java
@@ -1,4 +1,4 @@
-package edu.ucsb.cs48.s20.demo.controllers;
+package edu.ucsb.cs48.s20.demo.ui;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,9 +36,12 @@ import org.junit.Before;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import org.springframework.test.context.web.WebAppConfiguration;
 
+@SpringBootTest
+@AutoConfigureMockMvc
+@WebAppConfiguration
 @RunWith(SpringRunner.class)
-@WebMvcTest(ApplicationController.class)
 public class HomePageHTMLTest {
 
     @Autowired

--- a/src/test/java/edu/ucsb/cs48/s20/demo/ui/HomePageHTMLTest.java
+++ b/src/test/java/edu/ucsb/cs48/s20/demo/ui/HomePageHTMLTest.java
@@ -25,7 +25,6 @@ import edu.ucsb.cs48.s20.demo.services.MembershipService;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
 
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -34,7 +33,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.junit.Before;
 import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import org.springframework.test.context.web.WebAppConfiguration;
 

--- a/src/test/java/edu/ucsb/cs48/s20/demo/ui/HomePageHTMLTest.java
+++ b/src/test/java/edu/ucsb/cs48/s20/demo/ui/HomePageHTMLTest.java
@@ -136,4 +136,24 @@ public class HomePageHTMLTest {
         .andExpect(xpath("/html/body/div/div/div/table/tbody/tr[2]/td").string(expectedDeets));        
 
     }
+
+     /*when a student has submitted an idea, there is a flash message indicating how many ideas they need to review*/
+    @Test
+    public void studentWithSubmission_hasReviewFlashMsg() throws Exception{
+        ProjectIdea pi = new ProjectIdea();
+        pi.setTitle("someTitle");
+        pi.setDetails("someDeets");
+
+        Student person = new Student();
+        person.setProjectIdea(pi);
+
+        when(aca.getIsStudent((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(true);
+        when(sfa.needsToSubmitProjectIdea((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(false);
+        when(sfa.getReviewsNeeded((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(5);
+        when(sfa.getStudent((OAuth2AuthenticationToken) mockAuthentication)).thenReturn(person);
+        
+        mvc.perform(MockMvcRequestBuilders.get("/").with(authentication(mockAuthentication)).accept(MediaType.TEXT_HTML)).andExpect(status().isOk())
+        .andExpect(xpath("/html/body/div/div/div/div/div/span").string("You must review 5 more project ideas. "));
+    }
+
 }


### PR DESCRIPTION
* UI tests for the flow of a student submitting an idea from the homepage
  - Moved the HomePageTest file to the test UI directory
  - Anyone can access the homepage without logging in
  - A logged-in student will see the text box for submitting an idea if they have not already submitted an idea
  - If the student has submitted an idea, there is no text box
     - Instead, the title and details of their idea are displayed
     - There is a message indicating how many other ideas they need to review

* Full tests for the ProjectIdeasController, which handles submissions via add action
--> also covered all other controller actions for completeness
  - A valid idea submission must satisfy the length validations for each field and be associated with a student. If it is valid, it is saved to the DB, and the student is updated to reflect their association with their idea.
  - An invalid idea submission triggers no DB operations
  - Only admins can trigger the delete action
     - If the idea does not exist then no deletion occurs and an error message is displayed
     - Otherwise, it is removed from the DB, the student is updated now that they have no associated idea, and a success message is displayed.
  - Only admins can access the ideas index page, where they should see a list of all the ideas in the DB